### PR TITLE
Do not specify source in plugin Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,1 @@
-source 'http://rubygems.org'
 gem "ri_cal"


### PR DESCRIPTION
Do not specify the source in the plugin's Gemfile as it should be using the same source as redmine.

This eliminates a bundle install warning.
